### PR TITLE
refactor(nextjs): move ArcGIS styles CDN to EsriMap css module

### DIFF
--- a/nextjs-arcgis-core/styles/EsriMap.module.css
+++ b/nextjs-arcgis-core/styles/EsriMap.module.css
@@ -1,3 +1,5 @@
+@import 'https://js.arcgis.com/4.25/@arcgis/core/assets/esri/themes/light/main.css';
+
 .mapDiv {
   padding: 0;
   margin: 0;

--- a/nextjs-arcgis-core/styles/globals.css
+++ b/nextjs-arcgis-core/styles/globals.css
@@ -1,4 +1,3 @@
-@import 'https://js.arcgis.com/4.25/@arcgis/core/assets/esri/themes/light/main.css';
 :root {
   --max-width: 1100px;
   --border-radius: 12px;


### PR DESCRIPTION
Moves the CDN import to the EsriMap CSS module