### PR TITLE
docs: use npm package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ArcGIS Core with Sever Side Rendering Frameworks
+# @arcgis/core with Sever Side Rendering Frameworks
 
 The samples in this repo were created for a [blog post](https://www.esri.com/arcgis-blog/products/js-api-arcgis/developers/ssr-esm/), and extend those [provided by Esri](https://github.com/Esri/jsapi-resources/tree/master/esm-samples). The samples integrate the [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) build of the ArcGIS Maps SDK for JavaScript with Server Side Rendering frameworks (plus Svelte, because Svelte is great).
 

--- a/nextjs-arcgis-core/README.md
+++ b/nextjs-arcgis-core/README.md
@@ -1,4 +1,4 @@
-# ArcGIS Core with NextJS
+# @arcgis/core with NextJS
 
 The ArcGIS Maps SDK for JavaScript can not render a map on the server, since it does not have access to the DOM. Therefore, you need to disable SSR for the map component:
 

--- a/nextjs-arcgis-core/pages/index.js
+++ b/nextjs-arcgis-core/pages/index.js
@@ -14,10 +14,7 @@ export async function getStaticProps() {
   };
 }
 
-/**
- * ArcGIS Core does not currently work with SSR,
- * so we need to disable it for the map component
- */
+// @arcgis/core does not currently work with SSR, so we need to disable it for the map component
 const EsriMapWithNoSSR = dynamic(() => import('../components/EsriMap'), {
   ssr: false
 });

--- a/nuxtjs-arcgis-core/README.md
+++ b/nuxtjs-arcgis-core/README.md
@@ -1,4 +1,4 @@
-# ArcGIS Core with NuxtJS
+# @arcgis/core with NuxtJS
 
 ## Rendering a Map
 

--- a/sapper-arcgis-core/README.md
+++ b/sapper-arcgis-core/README.md
@@ -1,4 +1,4 @@
-# ArcGIS Core with Sapper
+# @arcgis/core with Sapper
 
 ### Deprecated
 

--- a/svelte-arcgis-core/README.md
+++ b/svelte-arcgis-core/README.md
@@ -1,4 +1,4 @@
-# ArcGIS Core with Svelte
+# @arcgis/core with Svelte
 
 Everything you need to build a Svelte project, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte).
 

--- a/sveltekit-arcgis-core/README.md
+++ b/sveltekit-arcgis-core/README.md
@@ -1,4 +1,4 @@
-# ArcGIS Core with SvelteKit
+# @arcgis/core with SvelteKit
 
 The ArcGIS Maps SDK for JavaScript can not render a map on the server, since it does not have access to the DOM. Therefore, you need to disable SSR for the map component. You can do this by dynamically importing the component in `onMount()`. Read [SvelteKit's FAQ answer about client side libraries](https://kit.svelte.dev/faq#integrations-how-do-i-use-a-client-side-only-library-that-depends-on-document-or-window) for more info.
 


### PR DESCRIPTION
Cleans up the doc to replace ArcGIS Core with the npm package name (@arcgis/core)